### PR TITLE
подвиг: начальная радиолокационная аскафа

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# Telegram
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_WEBAPP_URL=https://your-domain.com
+VITE_WS_URL=wss://your-domain.com/ws
+
+# Map providers
+GOOGLE_MAPS_API_KEY=
+MAPTILER_API_KEY=
+
+# Backend
+NODE_ENV=production
+PORT=8080
+PUBLIC_WS_URL=wss://your-domain.com
+PUBLIC_API_URL=https://your-domain.com/api
+JWT_SECRET=change_me
+
+# Database
+DATABASE_URL=postgresql://user:pass@db:5432/radar
+
+# Redis (BullMQ)
+REDIS_URL=redis://redis:6379
+
+# Ingest
+SOURCE_PULL_URL=https://example.com/alerts.json
+SOURCE_PULL_INTERVAL_CRON=*/2 * * * *
+WEBHOOK_SHARED_SECRET=change_me
+
+# Geo defaults
+DEFAULT_CENTER_LAT=43.238949
+DEFAULT_CENTER_LNG=76.889709
+DEFAULT_ZOOM=8

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
-
+node_modules
+.env
+build
+dist
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # dutti
+
+Monorepo scaffold for a Telegram-based UAV incident radar. It includes:
+
+- `apps/api` – Express server with Socket.IO and a stub Telegram bot.
+- `apps/web` – React + Vite WebApp that connects to the realtime API.
+- `packages/shared` – Shared Zod schemas and types.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   pnpm install
+   ```
+2. Copy `.env.example` to `.env` and adjust values. Be sure to supply a fresh `TELEGRAM_BOT_TOKEN` from [BotFather](https://t.me/BotFather) and configure `VITE_WS_URL` for the WebSocket endpoint.
+3. Start development servers:
+   ```bash
+   pnpm dev:api # in one terminal
+   pnpm dev:web # in another terminal
+   ```
+4. Or run the stack via Docker:
+   ```bash
+   docker-compose up --build
+   ```
+
+The API provides `/api/health` and `/api/ingest/webhook` endpoints. The WebApp connects to the WebSocket namespace at `/ws` and logs incoming incident events.
+
+This is an early foundation; major features from the project brief still need implementation.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:20-alpine AS build
+WORKDIR /repo
+
+# copy workspace files
+COPY pnpm-workspace.yaml package.json tsconfig.base.json ./
+COPY packages ./packages
+COPY apps/api/package.json apps/api/tsconfig.json apps/api/src ./apps/api/
+
+RUN corepack enable \
+  && pnpm install --filter api... --prod=false \
+  && pnpm -F @dutti/shared build \
+  && pnpm -F api build
+
+FROM node:20-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY --from=build /repo/apps/api/dist ./dist
+COPY --from=build /repo/apps/api/package.json ./package.json
+COPY --from=build /repo/apps/api/node_modules ./node_modules
+
+CMD ["node", "dist/index.js"]
+

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "test": "echo 'no tests for api'"
+  },
+  "dependencies": {
+    "@dutti/shared": "workspace:*",
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "socket.io": "^4.7.5",
+    "telegraf": "^4.16.3",
+    "zod": "^3.22.4",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,0 +1,76 @@
+import 'dotenv/config';
+import express from 'express';
+import cors from 'cors';
+import { createServer } from 'http';
+import { Server } from 'socket.io';
+import { Telegraf } from 'telegraf';
+import { IncidentInputSchema } from '@dutti/shared';
+
+const PORT = process.env.PORT || 8080;
+const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN || '';
+const TELEGRAM_WEBAPP_URL = process.env.TELEGRAM_WEBAPP_URL || '';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.get('/api/health', (_req, res) => {
+  res.json({ ok: true });
+});
+
+const httpServer = createServer(app);
+const io = new Server(httpServer, { path: '/ws', cors: { origin: '*' } });
+
+const WEBHOOK_SHARED_SECRET = process.env.WEBHOOK_SHARED_SECRET || '';
+
+app.post('/api/ingest/webhook', (req, res) => {
+  if (req.query.secret !== WEBHOOK_SHARED_SECRET) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+  const payload = req.body;
+  try {
+    const incidents = Array.isArray(payload)
+      ? payload.map((p: unknown) => IncidentInputSchema.parse(p))
+      : [IncidentInputSchema.parse(payload)];
+    io.emit('incidents:new', incidents);
+    res.json({ received: incidents.length });
+  } catch (err) {
+    res.status(400).json({ error: (err as Error).message });
+  }
+});
+
+if (TELEGRAM_BOT_TOKEN) {
+  const bot = new Telegraf(TELEGRAM_BOT_TOKEN);
+
+  bot.start((ctx) => {
+    if (TELEGRAM_WEBAPP_URL) {
+      ctx.reply('Open Radar', {
+        reply_markup: {
+          inline_keyboard: [
+            [{ text: 'Open Radar', web_app: { url: TELEGRAM_WEBAPP_URL } }],
+          ],
+        },
+      });
+    } else {
+      ctx.reply('Radar coming soon');
+    }
+  });
+
+  bot.launch().then(() => console.log('Bot started'));
+  const stopBot = () => bot.stop();
+  process.once('SIGINT', stopBot);
+  process.once('SIGTERM', stopBot);
+} else {
+  console.warn('TELEGRAM_BOT_TOKEN not set, bot disabled');
+}
+
+const shutdown = () => {
+  io.close();
+  httpServer.close(() => process.exit(0));
+};
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+
+httpServer.listen(PORT, () => {
+  console.log(`API server listening on ${PORT}`);
+});

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:20-alpine AS build
+WORKDIR /repo
+
+COPY pnpm-workspace.yaml package.json tsconfig.base.json ./
+COPY packages ./packages
+COPY apps/web/package.json apps/web/tsconfig.json apps/web/vite.config.ts apps/web/src apps/web/index.html ./apps/web/
+
+RUN corepack enable \
+  && pnpm install --filter web... --prod=false \
+  && pnpm -F web build
+
+FROM node:20-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY --from=build /repo/apps/web/dist ./dist
+COPY --from=build /repo/apps/web/package.json ./package.json
+COPY --from=build /repo/apps/web/node_modules ./node_modules
+
+EXPOSE 3000
+CMD ["node_modules/.bin/vite", "preview", "--host", "0.0.0.0", "--port", "3000"]
+

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Radar</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -p tsconfig.json && vite build",
+    "preview": "vite preview",
+    "test": "echo 'no tests for web'"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "socket.io-client": "^4.7.5"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0"
+  }
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { io } from 'socket.io-client';
+
+const wsEnv = import.meta.env.VITE_WS_URL || 'ws://localhost:8080/ws';
+const wsURL = new URL(wsEnv);
+
+export default function App() {
+  useEffect(() => {
+    const socket = io(wsURL.origin, { path: wsURL.pathname });
+    socket.on('incidents:new', (data) => {
+      console.log('new incidents', data);
+    });
+    return () => {
+      socket.close();
+    };
+  }, []);
+
+  return <div>Radar coming soon</div>;
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
+  },
+  "include": ["src"]
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.9'
+services:
+  api:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+    env_file: .env
+    expose:
+      - "8080"
+    depends_on:
+      - db
+      - redis
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+    env_file: .env
+    expose:
+      - "3000"
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: pass
+      POSTGRES_DB: radar
+    volumes:
+      - db-data:/var/lib/postgresql/data
+  redis:
+    image: redis:7
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - api
+      - web
+volumes:
+  db-data:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,18 @@
+events {}
+http {
+  server {
+    listen 80;
+    location / {
+      proxy_pass http://web:3000;
+    }
+    location /api/ {
+      proxy_pass http://api:8080/;
+    }
+    location /ws/ {
+      proxy_pass http://api:8080/ws/;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "dutti",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "build": "pnpm -r build",
+    "dev:api": "pnpm -F api dev",
+    "dev:web": "pnpm -F web dev",
+    "test": "pnpm -r test"
+  }
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@dutti/shared",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "echo 'no tests for shared'"
+  },
+  "dependencies": {
+    "zod": "^3.22.4"
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const IncidentInputSchema = z.object({
+  source: z.string(),
+  type: z.enum(['UAV', 'AIR_ALERT', 'EXPLOSION', 'JAMMING', 'OTHER']),
+  severity: z.enum(['LOW', 'MEDIUM', 'HIGH', 'CRITICAL']),
+  lat: z.number().min(-90).max(90),
+  lng: z.number().min(-180).max(180),
+  radius_m: z.number().int().positive().optional(),
+  heading_deg: z.number().int().min(0).max(360).optional(),
+  speed_kmh: z.number().int().nonnegative().optional(),
+  occurred_at: z.string().datetime(),
+  raw: z.any().optional()
+});
+
+export type IncidentInput = z.infer<typeof IncidentInputSchema>;

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true
+  },
+  "include": ["src"]
+}
+

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'apps/*'
+  - 'packages/*'

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- switch to NodeNext base config and build shared package to dist
- add Dockerfiles for api and web with nginx reverse proxy
- wire VITE_WS_URL env, enable CORS and webhook secret, and cleanly shut down server

## Testing
- `pnpm install` (fails: ERR_PNPM_FETCH_403 GET https://registry.npmjs.org/tsx)
- `pnpm -r build` (fails: Cannot find module 'zod')
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68968e31e2d88326a7510a11671a3b1b